### PR TITLE
chore: set `mooncake-transfer-engine>=0.3.5`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
 
 [project.optional-dependencies]
 p2p = [
-    "mooncake-transfer-engine",
+    # `batch_register_memory` is introduced in 0.3.5
+    "mooncake-transfer-engine>=0.3.5",
 ]
 
 [build-system]


### PR DESCRIPTION
See https://github.com/MoonshotAI/checkpoint-engine/issues/12#issuecomment-3301277062. It seems `batch_register_memory` is introduced in [mooncake-transfer-engine>=0.3.5](https://github.com/kvcache-ai/Mooncake/blob/v0.3.5/mooncake-integration/transfer_engine/transfer_engine_py.cpp#L661)