### PR TITLE
A more reasonable way to obtain RDMA devices

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -27,4 +27,4 @@ jobs:
         pip install .[p2p]
     - name: Do CPU tests with pytest
       run: |
-        pytest -v -m "cpu" tests/
+        pytest -v -m "not gpu" tests/

--- a/checkpoint_engine/ps.py
+++ b/checkpoint_engine/ps.py
@@ -332,10 +332,10 @@ def _parse_NCCL_IB_HCA(value: str, available_devices: list[str]) -> list[str]:
     Please note that when '^' and '=' appear together, only '^=' is allowed, '=^' is not supported.
 
     Examples:
-    - NCCL_IB_HCA=mlx5: Use all cards starting with mlx5.
-    - NCCL_IB_HCA==mlx5_0,mlx5_1 : Use specific cards mlx5_0 and mlx5_1.
-    - NCCL_IB_HCA=^mlx5: Use all cards except those starting with mlx5.
-    - NCCL_IB_HCA=^=mlx5_0,mlx5_1: Use all cards except mlx5_0 and mlx5_1.
+    - `NCCL_IB_HCA="mlx5"`: Use all cards starting with `mlx5`.
+    - `NCCL_IB_HCA="=mlx5_0,mlx5_1"`: Use specific cards `mlx5_0` and `mlx5_1`.
+    - `NCCL_IB_HCA="^mlx5"`: Use all cards except those starting with `mlx5`.
+    - `NCCL_IB_HCA="^=mlx5_0,mlx5_1"`: Use all cards except `mlx5_0` and `mlx5_1`.
     """
     max_hcas = 32
     if not value or value.strip() == "":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,5 @@ ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 markers = [
-    "cpu: marks tests as CPU test (deselect with '-m \"not cpu\"')",
     "gpu: marks tests as GPU test (deselect with '-m \"not gpu\"')",
 ]

--- a/tests/test_rdma_parser.py
+++ b/tests/test_rdma_parser.py
@@ -17,7 +17,6 @@ def mock_available_devices() -> list[str]:
     return ["mlx5_0", "mlx5_1", "mlx4_0", "mlx4_1"]
 
 
-@pytest.mark.cpu
 def test_detect_ibv_list():
     """Test detection of _ibv_get_device_list function"""
     # Skip this test if no real infiniband devices exist
@@ -30,7 +29,6 @@ def test_detect_ibv_list():
         assert isinstance(devices, list)
 
 
-@pytest.mark.cpu
 def test_parse_max_hcas_limit():
     """Test maximum HCA quantity limit"""
     # Create mock data with more than 32 devices
@@ -40,7 +38,6 @@ def test_parse_max_hcas_limit():
     assert result == many_devices[:32]
 
 
-@pytest.mark.cpu
 def test_get_rdma_devices_no_env_vars(mock_available_devices: list[str]):
     """Test _get_rdma_devices with no environment variables"""
     with (
@@ -51,7 +48,6 @@ def test_get_rdma_devices_no_env_vars(mock_available_devices: list[str]):
         assert sorted(devices) == sorted(mock_available_devices)
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize(
     "input_value,expected",
     [
@@ -74,7 +70,6 @@ def test_parse_basic_cases(
     assert result == expected
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize(
     "input_value,expected",
     [
@@ -105,7 +100,6 @@ def test_parse_various_patterns(
     assert result == expected
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize(
     "input_value,expected_result,expected_warning",
     [
@@ -133,7 +127,6 @@ def test_parse_exact_match_with_nonexistent_device(
         mock_logger.warning.assert_called_once_with(expected_warning)
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize(
     "env_var_name,env_var_value,expected_devices",
     [
@@ -161,7 +154,6 @@ def test_get_rdma_devices_with_env_vars(
         assert sorted(devices) == sorted(expected_devices)
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize(
     "local_rank,gpu_count,expected_device",
     [
@@ -179,7 +171,6 @@ def test_get_my_rdma_device_basic(local_rank: int, gpu_count: int, expected_devi
     assert device == expected_device
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize(
     "local_rank,gpu_count,devices,error",
     [


### PR DESCRIPTION
resolve: #35 

_parse_NCCL_IB_HCA method added, supporting exact match( "=" ), exclude( "^" ) prefix. Port specifications( ":" ) is not supported because mooncake transfer engine doesn't support it yet.

https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#id8

