### PR TITLE
fix: use tcp store_based_barrier to control p2p update synchronization

### DIFF
--- a/checkpoint_engine/ps.py
+++ b/checkpoint_engine/ps.py
@@ -1097,7 +1097,7 @@ class ParameterServer:
                     timeout=timeout,
                     is_master=self._rank == 0,
                 )
-            # if both ranks is None or [], it will use fully broadcast to update to all ranks
+            # if ranks is None or [], it will use fully broadcast to update to all ranks
             ranks_group = dist.new_group(ranks if ranks else None)
             self._update_per_bucket(checkpoint_name, req_func, ranks_group, ranks)
             self.store_based_barrier(manager_store)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -82,7 +82,7 @@ def checker_proc_with_error(
         try:
             trigger_error(socket_paths)
         except RuntimeError as e:
-            assert str(e) == "Failed to update weights due to remote errors"
+            assert str(e) == "Some workers failed to update weights"
 
 
 def checker_proc(rank: int, device_uuid: str, named_tensors: dict[str, torch.Tensor], queue: Queue):
@@ -177,7 +177,13 @@ def run(
             ],
         ),
         ("test_with_remote_error", [[]]),
-        # ("long_test_no_error", [list(random.sample(range(get_world_size()), k=num_ranks)) for num_ranks in range(get_world_size() + 1)]),
+        (
+            "test_no_error",
+            [
+                list(random.sample(range(get_world_size()), k=num_ranks))
+                for num_ranks in range(get_world_size() + 1)
+            ],
+        ),
     ],
 )
 def test_update(test_name: str, rank_list: list[list[int]] | None):


### PR DESCRIPTION
Act a TCP Store based barrier in `ParameterServer.update` method. Rewrite the logic of process management. Deprecate the logic `if self._rank not in ranks: return`. Do a `_store_based_barrier` among all ranks to make sure a synchronization before they quit `update` method. Also all communication are done in a sub group, deprecating `_get_bcast_rank_map` and `init_process_group_for_ranks` methods