### PR TITLE
bugfix: reset global meta when gather meta

### DIFF
--- a/checkpoint_engine/ps.py
+++ b/checkpoint_engine/ps.py
@@ -899,6 +899,8 @@ class ParameterServer:
 
         dist.all_gather_object(metas_lst, metas)
 
+        self._current_global_parameter_metas = {}
+
         num_parameters = 0
         all_hosts: list[str] = []
         global_device_uuids: list[str] = []


### PR DESCRIPTION
`_current_global_parameter_metas` needs to be cleaned when gathering meta.