### PR TITLE
fix p2p update error when disable_h2d_buffer is true

### DIFF
--- a/checkpoint_engine/ps.py
+++ b/checkpoint_engine/ps.py
@@ -778,7 +778,9 @@ class ParameterServer:
         if p2p_update:
             # p2p store need to register buffer to let other ranks read
             p2p_ipc_buffer_name = "__ipc_buffer__"
-            self._p2p_store.register_named_tensors({p2p_ipc_buffer_name: buffer if disable_h2d_buffer else h2d_buffer})
+            self._p2p_store.register_named_tensors(
+                {p2p_ipc_buffer_name: buffer if disable_h2d_buffer else h2d_buffer}
+            )
         handle = reduce_tensor(buffer)
 
         buckets_by_receiver_rank: dict[int, list[H2DBucket]] = defaultdict(list)
@@ -826,7 +828,12 @@ class ParameterServer:
                         if disable_h2d_buffer:
                             if p2p_update:
                                 assert bucket == receiver_rank_buckets[i][1]
-                            self._copy_to_buffer(checkpoint_name, bucket, buffer_b, receiver_rank_buckets[i][0] if p2p_update else None)
+                            self._copy_to_buffer(
+                                checkpoint_name,
+                                bucket,
+                                buffer_b,
+                                receiver_rank_buckets[i][0] if p2p_update else None,
+                            )
                         else:
                             buffer_b.data.copy_(h2d_buffer[: bucket.size])
                     dist.broadcast(buffer_b, src=receiver_rank, group=ranks_group)


### PR DESCRIPTION
This MR fixes an issue introduced by https://github.com/MoonshotAI/checkpoint-engine/pull/28.

The MR https://github.com/MoonshotAI/checkpoint-engine/pull/28 modified the trigger condition of the P2P broadcast operation, requiring the H2D buffer. If the free GPU memory could not meet the condition for H2D operations, it would set the H2D buffer to None, preventing any communication buffer from being registered with the P2P store. This caused subsequent synchronization of the weight buffer to follow the wrong path, resulting in GPU memory synchronization errors.

In this fix MR, if H2D operations are available, the H2D buffer is registered with the P2P store when P2P operation are used to update weights; otherwise, the receive buffer is directly registered with the P2P store. And then, the corresponding `copy_to_buffer` operation is then executed through the right path.