### PR TITLE
fix: set current CUDA device in _inplace_pin_memory function

### DIFF
--- a/checkpoint_engine/pin_memory.py
+++ b/checkpoint_engine/pin_memory.py
@@ -191,6 +191,8 @@ def _load_checkpoint(files: list[str]) -> dict[str, torch.Tensor]:
 
 
 def _inplace_pin_memory(files: list[str], rank: int | None = None) -> list[MemoryBuffer]:
+    device_index = torch.cuda.current_device()
+
     def _parse_and_pin_from_safetensors(file_path: str) -> MemoryBuffer:
         """
         safetensors format see https://huggingface.co/docs/safetensors/en/index#format.
@@ -204,6 +206,7 @@ def _inplace_pin_memory(files: list[str], rank: int | None = None) -> list[Memor
             Pin the memory of tensor in-place.
             See: https://github.com/pytorch/pytorch/issues/32167
             """
+            torch.cuda.set_device(device_index)
             cudart = torch.cuda.cudart()
             r = cudart.cudaHostRegister(t.data_ptr(), t.numel() * t.element_size(), 0)
             assert r == 0, f"pin memory error, error code: {r}"

--- a/examples/update.py
+++ b/examples/update.py
@@ -14,7 +14,8 @@ import torch.distributed as dist
 from loguru import logger
 from safetensors import safe_open
 
-from checkpoint_engine.ps import ParameterServer, request_inference_to_update
+from checkpoint_engine import request_inference_to_update
+from checkpoint_engine.ps import ParameterServer
 
 
 @contextmanager


### PR DESCRIPTION
This pull request introduces a minor import adjustment and a fix to device handling when pinning memory for CUDA tensors. The main changes ensure that memory pinning happens on the correct CUDA device and resolve an import path issue.

CUDA device handling improvements:

* In `checkpoint_engine/pin_memory.py`, the current CUDA device is now explicitly retrieved and set (`device_index = torch.cuda.current_device()` and `torch.cuda.set_device(device_index)`) before pinning memory, ensuring that pinning occurs on the correct device. [[1]](diffhunk://#diff-c5d32d7dee2ee6695e5657c2ea95ab9c65b342205be9007a87db85c98721114cR194) [[2]](diffhunk://#diff-c5d32d7dee2ee6695e5657c2ea95ab9c65b342205be9007a87db85c98721114cR208)

Import path correction:

* In `examples/update.py`, the import for `request_inference_to_update` is fixed by importing it directly from `checkpoint_engine` instead of `checkpoint_engine.ps`, resolving a potential import error.